### PR TITLE
Add VEP and protein prediction workflows

### DIFF
--- a/new_pipeline_dx/.gitignore
+++ b/new_pipeline_dx/.gitignore
@@ -1,0 +1,6 @@
+*/work
+*/.nextflow*
+*/input
+*/outdir
+*/reports
+*/scripts

--- a/new_pipeline_dx/VEP/README.md
+++ b/new_pipeline_dx/VEP/README.md
@@ -1,0 +1,106 @@
+## Nextflow VEP pipeline
+
+The nextflow pipeline aims to run VEP faster utilising simple parallelisation. It is deployable on an individual Linux machine or on computing clusters running lsf or slurm (not tested). The process can be summarised briefly by the following steps:
+
+ * Splitting the VCF chromosome-wise
+ * Running VEP on chromosome-wise VCFs in parallel
+ * Merging VEP outputs into a single file
+
+
+##### Table of contents
+
+* [Installation and requirements](#install)
+* [Pipeline setup](#setup)
+* [Usage](#usage)
+* [Example](#example)
+
+---
+<a id="install"></a>
+### Installation and requirements
+
+The nextflow pipeline requires the following dependencies:
+
+  * **[Nextflow](https://www.nextflow.io)** (tested on 21.10.0)
+  * **[Singularity](https://sylabs.io/guides/3.7/admin-guide/installation.html)** (tested on 3.7)
+
+<a id="setup"></a>
+### Pipeline setup
+
+#### Singularity images
+Singularity images are required in order to run the following tools:
+
+  * bcftools
+  * VEP
+
+The singularity images can be fetched by running:
+```bash
+   ./setup-images.sh
+```
+
+#### Config files
+
+The following config files are used and can be modified depending on user requirements:
+
+  * VEP config file
+  ``` bash
+      cp nf_config/vep.ini.template nf_config/vep.ini
+  ```
+
+
+  * Nextflow config file
+
+    `nf_config/nextflow.config` has the default options for running the pipeline. The file can be modified to change the default options or override them using command line options
+
+ Currently supported profiles for executors are standard (local), LSF and SLURM (untested!). As mentioned SLURM is untested at present, if you are running this pipeline on a slurm compute cluster and encounter problems, please contact us with details (raise a ticket on the github) and we can investigate.
+ NB: If no profile is mentioned, the pipeline takes the standard profile.
+
+---
+<a id="usage"></a>
+### Usage
+
+```bash
+  nextflow run workflows/run_vep.nf \
+  -C nf_config/nextflow.config \
+  --vcf <path-to-vcf> \
+  --chros 1,2 \
+  -profile <standard or lsf or slurm>
+```
+
+#### Options
+
+```bash
+  --vcf VCF               VCF that will be split. Currently supports sorted and bgzipped file
+  --outdir DIRNAME        Name of output dir. Default: outdir
+  --vep_config FILENAME   VEP config file. Default: nf_config/vep.ini
+  --chros LIST_OF_CHROS   Comma-separated list of chromosomes to generate. i.e. 1,2,..., Default: 1,2,...X,Y,MT
+  --cpus INT              Number of CPUs to use. Default 1.
+```
+NB: File paths are expected to be absolute paths.
+
+---
+<a id="example"></a>
+### Example
+
+```bash
+  bgzip -c $PWD/examples/clinvar-testset/input.vcf > $PWD/examples/clinvar-testset/input.vcf.gz
+
+  nextflow -C nf_config/nextflow.config \
+    run workflows/run_vep.nf \
+    --vcf $PWD/examples/clinvar-testset/input.vcf.gz \
+    -profile lsf
+ ```
+The above commands start the pipeline and generate the output file upon completion.
+
+#### Output validation
+
+```bash
+  singularity-images/bcftools.sif bcftools view \
+    -H outdir/merged-file.vcf.gz \
+    -r 1
+```
+Expected result
+
+```bash
+1 925952  1019397 G A . . ALLELEID=1003021;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000001.11:g.925952G>A;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Uncertain_significance;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=SAMD11:148398;MC=SO:0001583|missense_variant;ORIGIN=1;CSQ=A|upstream_gene_variant|MODIFIER|SAMD11|ENSG00000187634|Transcript|ENST00000341065|protein_coding|||||||||||4360|1|cds_start_NF|HGNC|HGNC:28706,A|missense_variant|MODERATE|SAMD11|ENSG00000187634|Transcript|ENST00000342066|protein_coding|2/14||||101|11|4|G/E|gGg/gAg|||1||HGNC|HGNC:28706,A|missense_variant|MODERATE|SAMD11|ENSG00000187634|Transcript|ENST00000437963|protein_coding|2/5||||71|11|4|G/E|gGg/gAg|||1|cds_end_NF|HGNC|HGNC:28706,A|upstream_gene_variant|MODIFIER|LINC02593|ENSG00000223764|Transcript|ENST00000609207|retained_intron|||||||||||4936|-1||HGNC|HGNC:53933,A|missense_variant|MODERATE|SAMD11|ENSG00000187634|Transcript|ENST00000616016|protein_coding|2/14||||1057|548|183|G/E|gGg/gAg|||1||HGNC|HGNC:28706,A|missense_variant|MODERATE|SAMD11|ENSG00000187634|Transcript|ENST00000616125|protein_coding|1/11||||11|11|4|G/E|gGg/gAg|||1|cds_start_NF|HGNC|HGNC:28706,A|missense_variant|MODERATE|SAMD11|ENSG00000187634|Transcript|ENST00000617307|protein_coding|1/13||||11|11|4|G/E|gGg/gAg|||1|cds_start_NF|HGNC|HGNC:28706,A|missense_variant|MODERATE|SAMD11|ENSG00000187634|Transcript|ENST00000618181|protein_coding|1/10||||11|11|4|G/E|gGg/gAg|||1|cds_start_NF|HGNC|HGNC:28706,A|missense_variant|MODERATE|SAMD11|ENSG00000187634|Transcript|ENST00000618323|protein_coding|2/14||||1057|548|183|G/E|gGg/gAg|||1||HGNC|HGNC:28706,A|missense_variant|MODERATE|SAMD11|ENSG00000187634|Transcript|ENST00000618779|protein_coding|1/12||||11|11|4|G/E|gGg/gAg|||1|cds_start_NF|HGNC|HGNC:28706,A|missense_variant|MODERATE|SAMD11|ENSG00000187634|Transcript|ENST00000622503|protein_coding|1/13||||11|11|4|G/E|gGg/gAg|||1|cds_start_NF|HGNC|HGNC:28706
+1 930139  1125147 C T . . ALLELEID=1110865;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000001.11:g.930139C>T;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=SAMD11:148398;MC=SO:0001627|intron_variant;ORIGIN=1;CSQ=T|upstream_gene_variant|MODIFIER|SAMD11|ENSG00000187634|Transcript|ENST00000341065|protein_coding|||||||||||173|1|cds_start_NF|HGNC|HGNC:28706,T|intron_variant|MODIFIER|SAMD11|ENSG00000187634|Transcript|ENST00000342066|protein_coding||2/13||||||||||1||HGNC|HGNC:28706,T|intron_variant|MODIFIER|SAMD11|ENSG00000187634|Transcript|ENST00000437963|protein_coding||2/4||||||||||1|cds_end_NF|HGNC|HGNC:28706,T|intron_variant|MODIFIER|SAMD11|ENSG00000187634|Transcript|ENST00000616016|protein_coding||2/13||||||||||1||HGNC|HGNC:28706,T|intron_variant|MODIFIER|SAMD11|ENSG00000187634|Transcript|ENST00000616125|protein_coding||1/10||||||||||1|cds_start_NF|HGNC|HGNC:28706,T|intron_variant|MODIFIER|SAMD11|ENSG00000187634|Transcript|ENST00000617307|protein_coding||1/12||||||||||1|cds_start_NF|HGNC|HGNC:28706,T|intron_variant|MODIFIER|SAMD11|ENSG00000187634|Transcript|ENST00000618181|protein_coding||1/9||||||||||1|cds_start_NF|HGNC|HGNC:28706,T|intron_variant|MODIFIER|SAMD11|ENSG00000187634|Transcript|ENST00000618323|protein_coding||2/13||||||||||1||HGNC|HGNC:28706,T|intron_variant|MODIFIER|SAMD11|ENSG00000187634|Transcript|ENST00000618779|protein_coding||1/11||||||||||1|cds_start_NF|HGNC|HGNC:28706,T|intron_variant|MODIFIER|SAMD11|ENSG00000187634|Transcript|ENST00000622503|protein_coding||1/12||||||||||1|cds_start_NF|HGNC|HGNC:28706
+```

--- a/new_pipeline_dx/VEP/examples/clinvar-testset/input.vcf
+++ b/new_pipeline_dx/VEP/examples/clinvar-testset/input.vcf
@@ -1,0 +1,107 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=2021-10-25
+##source=ClinVar
+##reference=GRCh38
+##ID=<Description="ClinVar Variation ID">
+##INFO=<ID=AF_ESP,Number=1,Type=Float,Description="allele frequencies from GO-ESP">
+##INFO=<ID=AF_EXAC,Number=1,Type=Float,Description="allele frequencies from ExAC">
+##INFO=<ID=AF_TGP,Number=1,Type=Float,Description="allele frequencies from TGP">
+##INFO=<ID=ALLELEID,Number=1,Type=Integer,Description="the ClinVar Allele ID">
+##INFO=<ID=CLNDN,Number=.,Type=String,Description="ClinVar's preferred disease name for the concept specified by disease identifiers in CLNDISDB">
+##INFO=<ID=CLNDNINCL,Number=.,Type=String,Description="For included Variant : ClinVar's preferred disease name for the concept specified by disease identifiers in CLNDISDB">
+##INFO=<ID=CLNDISDB,Number=.,Type=String,Description="Tag-value pairs of disease database name and identifier, e.g. OMIM:NNNNNN">
+##INFO=<ID=CLNDISDBINCL,Number=.,Type=String,Description="For included Variant: Tag-value pairs of disease database name and identifier, e.g. OMIM:NNNNNN">
+##INFO=<ID=CLNHGVS,Number=.,Type=String,Description="Top-level (primary assembly, alt, or patch) HGVS expression.">
+##INFO=<ID=CLNREVSTAT,Number=.,Type=String,Description="ClinVar review status for the Variation ID">
+##INFO=<ID=CLNSIG,Number=.,Type=String,Description="Clinical significance for this single variant">
+##INFO=<ID=CLNSIGCONF,Number=.,Type=String,Description="Conflicting clinical significance for this single variant">
+##INFO=<ID=CLNSIGINCL,Number=.,Type=String,Description="Clinical significance for a haplotype or genotype that includes this variant. Reported as pairs of VariationID:clinical significance.">
+##INFO=<ID=CLNVC,Number=1,Type=String,Description="Variant type">
+##INFO=<ID=CLNVCSO,Number=1,Type=String,Description="Sequence Ontology id for variant type">
+##INFO=<ID=CLNVI,Number=.,Type=String,Description="the variant's clinical sources reported as tag-value pairs of database and variant identifier">
+##INFO=<ID=DBVARID,Number=.,Type=String,Description="nsv accessions from dbVar for the variant">
+##INFO=<ID=GENEINFO,Number=1,Type=String,Description="Gene(s) for the variant reported as gene symbol:gene id. The gene symbol and id are delimited by a colon (:) and each pair is delimited by a vertical bar (|)">
+##INFO=<ID=MC,Number=.,Type=String,Description="comma separated list of molecular consequence in the form of Sequence Ontology ID|molecular_consequence">
+##INFO=<ID=ORIGIN,Number=.,Type=String,Description="Allele origin. One or more of the following values may be added: 0 - unknown; 1 - germline; 2 - somatic; 4 - inherited; 8 - paternal; 16 - maternal; 32 - de-novo; 64 - biparental; 128 - uniparental; 256 - not-tested; 512 - tested-inconclusive; 1073741824 - other">
+##INFO=<ID=RS,Number=.,Type=String,Description="dbSNP ID (i.e. rs number)">
+##INFO=<ID=SSR,Number=1,Type=Integer,Description="Variant Suspect Reason Codes. One or more of the following values may be added: 0 - unspecified, 1 - Paralog, 2 - byEST, 4 - oldAlign, 8 - Para_EST, 16 - 1kg_failed, 1024 - other">
+##contig=<ID=1>
+##contig=<ID=2>
+##contig=<ID=3>
+##contig=<ID=4>
+##contig=<ID=5>
+##contig=<ID=6>
+##contig=<ID=7>
+##contig=<ID=8>
+##contig=<ID=9>
+##contig=<ID=10>
+##contig=<ID=11>
+##contig=<ID=12>
+##contig=<ID=13>
+##contig=<ID=14>
+##contig=<ID=15>
+##contig=<ID=16>
+##contig=<ID=17>
+##contig=<ID=18>
+##contig=<ID=19>
+##contig=<ID=20>
+##contig=<ID=21>
+##contig=<ID=22>
+##contig=<ID=X>
+##contig=<ID=Y>
+##contig=<ID=MT>
+##contig=<ID=NW_009646201.1>
+##bcftools_viewVersion=1.12+htslib-1.12
+##bcftools_viewCommand=view -R samples.txt -Oz -o test_data.vcf.gz /hps/nobackup/flicek/ensembl/variation/likhithas/work/nf_genomics_pipelines/test-data/vep-clinvar/clinvar.vcf.gz; Date=Wed Dec  1 18:57:14 2021
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	925952	1019397	G	A	.	.	ALLELEID=1003021;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000001.11:g.925952G>A;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Uncertain_significance;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=SAMD11:148398;MC=SO:0001583|missense_variant;ORIGIN=1
+1	930139	1125147	C	T	.	.	ALLELEID=1110865;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000001.11:g.930139C>T;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=SAMD11:148398;MC=SO:0001627|intron_variant;ORIGIN=1
+2	264985	717141	G	T	.	.	AF_ESP=0.00569;AF_TGP=0.00559;ALLELEID=719795;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000002.12:g.264985G>T;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=ACP1:52;MC=SO:0001583|missense_variant,SO:0001619|non-coding_transcript_variant;ORIGIN=1;RS=11691572
+2	265015	788388	G	A	.	.	AF_ESP=0.00907;AF_EXAC=0.00255;AF_TGP=0.00839;ALLELEID=779028;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000002.12:g.265015G>A;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=ACP1:52;MC=SO:0001627|intron_variant;ORIGIN=1;RS=116051772
+3	319781	983061	A	G	.	.	ALLELEID=970765;CLNDISDB=Human_Phenotype_Ontology:HP:0001250,Human_Phenotype_Ontology:HP:0001275,Human_Phenotype_Ontology:HP:0001303,Human_Phenotype_Ontology:HP:0002125,Human_Phenotype_Ontology:HP:0002182,Human_Phenotype_Ontology:HP:0002279,Human_Phenotype_Ontology:HP:0002306,Human_Phenotype_Ontology:HP:0002348,Human_Phenotype_Ontology:HP:0002391,Human_Phenotype_Ontology:HP:0002417,Human_Phenotype_Ontology:HP:0002430,Human_Phenotype_Ontology:HP:0002431,Human_Phenotype_Ontology:HP:0002432,Human_Phenotype_Ontology:HP:0002434,Human_Phenotype_Ontology:HP:0002437,Human_Phenotype_Ontology:HP:0002466,Human_Phenotype_Ontology:HP:0002479,Human_Phenotype_Ontology:HP:0002794,Human_Phenotype_Ontology:HP:0006997,Human_Phenotype_Ontology:HP:0010520,MedGen:C0036572;CLNDN=Seizures;CLNHGVS=NC_000003.12:g.319781A>G;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Uncertain_significance;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;CLNVI=Institute_of_Human_Genetics,_University_of_Leipzig_Medical_Center:CV_varv_321;GENEINFO=CHL1:10752;MC=SO:0001583|missense_variant;ORIGIN=0
+3	319804	718047	C	G	.	.	AF_ESP=0.00015;AF_EXAC=0.00056;AF_TGP=0.002;ALLELEID=720402;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000003.12:g.319804C>G;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=CHL1:10752;MC=SO:0001583|missense_variant;ORIGIN=1;RS=139673243
+4	86075	441007	AC	A	.	.	ALLELEID=434593;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000004.12:g.86076del;CLNREVSTAT=no_assertion_provided;CLNSIG=not_provided;CLNVC=Deletion;CLNVCSO=SO:0000159;GENEINFO=ZNF595:152687;MC=SO:0001589|frameshift_variant;ORIGIN=0;RS=1553801175
+4	86078	441008	G	GA	.	.	ALLELEID=434594;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000004.12:g.86078_86079insA;CLNREVSTAT=no_assertion_provided;CLNSIG=not_provided;CLNVC=Insertion;CLNVCSO=SO:0000667;GENEINFO=ZNF595:152687;MC=SO:0001589|frameshift_variant;ORIGIN=0;RS=1553801178
+5	143375	773164	C	T	.	.	AF_ESP=0.00362;AF_EXAC=0.00125;AF_TGP=0.0028;ALLELEID=777436;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000005.10:g.143375C>T;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=PLEKHG4B:153478;MC=SO:0001627|intron_variant;ORIGIN=1;RS=142208662
+5	151606	773165	G	A	.	.	AF_ESP=0.00338;AF_EXAC=0.00101;AF_TGP=0.0028;ALLELEID=777485;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000005.10:g.151606G>A;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=PLEKHG4B:153478;MC=SO:0001627|intron_variant;ORIGIN=1;RS=148716910
+6	348096	780116	C	T	.	.	AF_ESP=0.00254;AF_EXAC=0.00355;AF_TGP=0.0008;ALLELEID=779248;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000006.12:g.348096C>T;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=DUSP22:56940;MC=SO:0001627|intron_variant;ORIGIN=1;RS=200952897
+6	392783	1272812	G	A	.	.	ALLELEID=1262277;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000006.12:g.392783G>A;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=IRF4:3662;MC=SO:0001627|intron_variant;ORIGIN=1
+7	192800	1270004	G	A	.	.	ALLELEID=1258617;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000007.14:g.192800G>A;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=FAM20C:56975;MC=SO:0001623|5_prime_UTR_variant;ORIGIN=1
+7	193091	1245869	C	T	.	.	ALLELEID=1234538;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000007.14:g.193091C>T;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=FAM20C:56975;MC=SO:0001623|5_prime_UTR_variant;ORIGIN=1
+8	228116	636326	G	C	.	.	ALLELEID=624149;CLNDISDB=MONDO:MONDO:0012880,MedGen:C3552553,OMIM:612370;CLNDN=Hypogonadotropic_hypogonadism_5_with_or_without_anosmia;CLNHGVS=NC_000008.11:g.228116G>C;CLNREVSTAT=no_assertion_criteria_provided;CLNSIG=Pathogenic;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;ORIGIN=16;RS=1584891562
+8	1565843	1272088	C	A	.	.	ALLELEID=1262844;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000008.11:g.1565843C>A;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=DLGAP2:9228|DLGAP2-AS1:100507435;MC=SO:0001583|missense_variant;ORIGIN=1
+9	154795	768273	T	C	.	.	AF_ESP=0.76385;AF_EXAC=0.75555;AF_TGP=0.78694;ALLELEID=700940;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000009.12:g.154795T>C;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=CBWD1:55871;MC=SO:0001819|synonymous_variant;ORIGIN=1;RS=2785333
+9	214593	1279302	T	C	.	.	ALLELEID=1266585;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000009.12:g.214593T>C;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=DOCK8:81704|DOCK8-AS1:157983;MC=SO:0001619|non-coding_transcript_variant;ORIGIN=1
+10	47064	1176540	ACCTCCTCCTCGGCATACTCCTCATCCT	A	.	.	ALLELEID=1165944;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000010.11:g.47078_47104del;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_benign;CLNVC=Deletion;CLNVCSO=SO:0000159;GENEINFO=TUBB8:347688;MC=SO:0001822|inframe_deletion;ORIGIN=1
+10	47121	977661	T	C	.	.	ALLELEID=965787;CLNDISDB=MONDO:MONDO:0021573,MedGen:C4225210,OMIM:616780;CLNDN=Oocyte_maturation_defect_2;CLNHGVS=NC_000010.11:g.47121T>C;CLNREVSTAT=no_assertion_criteria_provided;CLNSIG=Likely_pathogenic;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=TUBB8:347688;MC=SO:0001583|missense_variant;ORIGIN=0
+11	193112	768404	C	T	.	.	AF_ESP=0.27341;AF_EXAC=0.30434;AF_TGP=0.26617;ALLELEID=701694;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000011.10:g.193112C>T;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=SCGB1C1:147199;MC=SO:0001583|missense_variant;ORIGIN=1;RS=7951297
+11	193722	768405	A	G	.	.	AF_ESP=0.10282;AF_EXAC=0.21159;ALLELEID=701695;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000011.10:g.193722A>G;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=SCGB1C1:147199;MC=SO:0001819|synonymous_variant;ORIGIN=1;RS=2294082
+12	66923	778075	A	G	.	.	AF_EXAC=0.00357;ALLELEID=702484;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000012.12:g.66923A>G;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=IQSEC3:440073;MC=SO:0001583|missense_variant;ORIGIN=1;RS=182407328
+12	67206	732536	G	A	.	.	ALLELEID=738845;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000012.12:g.67206G>A;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=IQSEC3:440073;MC=SO:0001819|synonymous_variant;ORIGIN=1;RS=782213176
+13	19467353	403563	TAA	T	.	.	ALLELEID=390113;CLNDISDB=MedGen:CN169374;CLNDN=not_specified;CLNHGVS=NC_000013.11:g.19467370_19467371del;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=Deletion;CLNVCSO=SO:0000159;GENEINFO=TPTE2:93492;MC=SO:0001627|intron_variant;ORIGIN=1;RS=71092363
+13	19852035	773691	G	C	.	.	AF_ESP=0.00154;AF_EXAC=0.00258;AF_TGP=0.0012;ALLELEID=702616;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000013.11:g.19852035G>C;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=ZMYM5:9205;MC=SO:0001587|nonsense;ORIGIN=1;RS=143318146
+14	19780619	770616	A	G	.	.	AF_EXAC=0.00166;AF_TGP=0.0014;ALLELEID=702793;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000014.9:g.19780619A>G;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=OR4M1:441670;MC=SO:0001819|synonymous_variant;ORIGIN=1;RS=202052638
+14	20292003	1048622	G	A	.	.	ALLELEID=1036710;CLNDISDB=MONDO:MONDO:0030999,MedGen:CN296165,OMIM:619244;CLNDN=Neurodevelopmental_disorder_with_cerebral_atrophy_and_variable_facial_dysmorphism;CLNHGVS=NC_000014.9:g.20292003G>A;CLNREVSTAT=no_assertion_criteria_provided;CLNSIG=Pathogenic;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;CLNVI=OMIM_Allelic_Variant:619014.0004;GENEINFO=TTC5:91875;MC=SO:0001587|nonsense;ORIGIN=1
+15	20534396	441140	A	C	.	.	ALLELEID=434769;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000015.10:g.20534396A>C;CLNREVSTAT=no_assertion_provided;CLNSIG=not_provided;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=GOLGA6L6:727832;MC=SO:0001583|missense_variant;ORIGIN=16;RS=4932676
+15	20534419	441139	A	G	.	.	ALLELEID=434770;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000015.10:g.20534419A>G;CLNREVSTAT=no_assertion_provided;CLNSIG=not_provided;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=GOLGA6L6:727832;MC=SO:0001583|missense_variant;ORIGIN=32;RS=4932675
+16	51636	1065610	G	A	.	.	ALLELEID=1053959;CLNDISDB=MedGen:CN296583,OMIM:619310;CLNDN=LEUKODYSTROPHY,_HYPOMYELINATING,_21;CLNHGVS=NC_000016.10:g.51636G>A;CLNREVSTAT=no_assertion_criteria_provided;CLNSIG=Pathogenic;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;CLNVI=OMIM_Allelic_Variant:606007.0001;GENEINFO=POLR3K:51728;MC=SO:0001583|missense_variant;ORIGIN=1
+16	59290	711634	G	A	.	.	AF_ESP=0.01169;AF_EXAC=0.00323;AF_TGP=0.00839;ALLELEID=729865;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000016.10:g.59290G>A;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=RHBDF1:64285;MC=SO:0001819|synonymous_variant;ORIGIN=1;RS=116064244
+17	519146	750404	G	A	.	.	ALLELEID=755973;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000017.11:g.519146G>A;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=VPS53:55275;MC=SO:0001819|synonymous_variant;ORIGIN=1;RS=922413168
+17	519155	724402	G	A	.	.	AF_ESP=0.00022;AF_EXAC=7e-05;ALLELEID=740882;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000017.11:g.519155G>A;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=VPS53:55275;MC=SO:0001819|synonymous_variant;ORIGIN=1;RS=376440772
+18	163302	755783	T	C	.	.	AF_EXAC=2e-05;ALLELEID=776768;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000018.10:g.163302T>C;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=USP14:9097;MC=SO:0001627|intron_variant;ORIGIN=1;RS=758025012
+18	163305	764797	C	T	.	.	AF_ESP=0.00169;AF_EXAC=0.00084;AF_TGP=0.0008;ALLELEID=776588;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000018.10:g.163305C>T;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=USP14:9097;MC=SO:0001627|intron_variant;ORIGIN=1;RS=368077279
+19	472422	916329	G	T	.	.	ALLELEID=904681;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000019.10:g.472422G>T;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=ODF3L2:284451;MC=SO:0001819|synonymous_variant,SO:0001623|5_prime_UTR_variant,SO:0001627|intron_variant;ORIGIN=1
+19	507545	790194	G	A	.	.	AF_EXAC=0.00082;AF_TGP=0.0018;ALLELEID=716623;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000019.10:g.507545G>A;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=TPGS1:91978;MC=SO:0001819|synonymous_variant;ORIGIN=1;RS=370127539
+20	145514	402585	GCAAA	G	.	.	ALLELEID=390334;CLNDISDB=MedGen:CN169374;CLNDN=not_specified;CLNHGVS=NC_000020.11:g.145515CAAA[1];CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=Microsatellite;CLNVCSO=SO:0000289;GENEINFO=DEFB126:81623;MC=SO:0001589|frameshift_variant;ORIGIN=1;RS=11467497
+20	145669	402586	ACC	A	.	.	ALLELEID=390451;CLNDISDB=MedGen:CN169374;CLNDN=not_specified;CLNHGVS=NC_000020.11:g.145673_145674del;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=Deletion;CLNVCSO=SO:0000159;GENEINFO=DEFB126:81623;MC=SO:0001589|frameshift_variant;ORIGIN=1;RS=11467417
+21	6116503	433140	C	T	.	.	ALLELEID=426703;CLNDISDB=MONDO:MONDO:0007295,MedGen:C0376532,Orphanet:ORPHA1945;CLNDN=Rolandic_epilepsy;CLNHGVS=NC_000021.9:g.6116503C>T;CLNREVSTAT=no_assertion_criteria_provided;CLNSIG=Pathogenic;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=LOC102724428:102724428;MC=SO:0001583|missense_variant;ORIGIN=1;RS=1555841977
+21	10541121	713837	G	T	.	.	ALLELEID=728830;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000021.9:g.10541121G>T;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=TPTE:7179;MC=SO:0001819|synonymous_variant,SO:0001627|intron_variant;ORIGIN=1;RS=374325784
+22	16591521	782172	G	T	.	.	AF_ESP=0.00554;AF_EXAC=0.00509;AF_TGP=0.00339;ALLELEID=717275;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_000022.11:g.16591521G>T;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=CCT8L2:150160;MC=SO:0001583|missense_variant;ORIGIN=1;RS=41277596
+22	17084966	340554	C	G	.	.	AF_TGP=0.00559;ALLELEID=352008;CLNDISDB=MONDO:MONDO:0013500,MedGen:C4310803,OMIM:613953;CLNDN=Immunodeficiency_51;CLNHGVS=NC_000022.11:g.17084966C>G;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;CLNVI=Illumina_Clinical_Services_Laboratory,Illumina:797125;GENEINFO=IL17RA:23765;ORIGIN=1;RS=562165706
+X	624386	265992	C	G	.	.	ALLELEID=260809;CLNDISDB=MONDO:MONDO:0010367,MedGen:C1845118,OMIM:300582,Orphanet:ORPHA314795;CLNDN=Short_stature,_idiopathic,_X-linked;CLNHGVS=NC_000023.11:g.624386C>G;CLNREVSTAT=no_assertion_criteria_provided;CLNSIG=Likely_benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=SHOX:6473;MC=SO:0001623|5_prime_UTR_variant;ORIGIN=1;RS=886039879
+X	624388	191363	T	TTTG	.	.	ALLELEID=189166;CLNDISDB=MONDO:MONDO:0010367,MedGen:C1845118,OMIM:300582,Orphanet:ORPHA314795;CLNDN=Short_stature,_idiopathic,_X-linked;CLNHGVS=NC_000023.11:g.624390_624391insGTT;CLNREVSTAT=no_assertion_criteria_provided;CLNSIG=Pathogenic;CLNVC=Insertion;CLNVCSO=SO:0000667;GENEINFO=SHOX:6473;MC=SO:0001623|5_prime_UTR_variant;RS=1556450972
+Y	2786976	258964	T	C	.	.	ALLELEID=257891;CLNDISDB=MedGen:CN169374;CLNDN=not_specified;CLNHGVS=NC_000024.10:g.2786976T>C;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_benign;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=SRY:6736;MC=SO:0001624|3_prime_UTR_variant;ORIGIN=1;RS=886038525
+Y	2787033	652674	AG	A	.	.	ALLELEID=650304;CLNDISDB=MONDO:MONDO:0020712,MedGen:C2748896,OMIM:400044;CLNDN=46,XY_sex_reversal,_type_1;CLNHGVS=NC_000024.10:g.2787034del;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Uncertain_significance;CLNVC=Deletion;CLNVCSO=SO:0000159;GENEINFO=SRY:6736;MC=SO:0001589|frameshift_variant;ORIGIN=1;RS=1603308285
+MT	263	441147	A	G	.	.	ALLELEID=434777;CLNDISDB=MedGen:CN517202;CLNDN=not_provided;CLNHGVS=NC_012920.1:m.263A>G;CLNREVSTAT=no_assertion_provided;CLNSIG=not_provided;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;ORIGIN=0;RS=2853515
+MT	578	689805	T	C	.	.	ALLELEID=677824;CLNDISDB=MONDO:MONDO:0010789,MedGen:C0162671,OMIM:540000,Orphanet:ORPHA550,SNOMED_CT:39925003;CLNDN=Juvenile_myopathy,_encephalopathy,_lactic_acidosis_AND_stroke;CLNHGVS=NC_012920.1:m.578T>C;CLNREVSTAT=criteria_provided,_single_submitter;CLNSIG=Likely_pathogenic;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=MT-TF:4558;ORIGIN=1;RS=1603218446

--- a/new_pipeline_dx/VEP/nf_config/README
+++ b/new_pipeline_dx/VEP/nf_config/README
@@ -1,0 +1,1 @@
+# DIR containing the relevant NF config files

--- a/new_pipeline_dx/VEP/nf_config/nextflow.config
+++ b/new_pipeline_dx/VEP/nf_config/nextflow.config
@@ -1,0 +1,58 @@
+params.singularity_dir = "$PWD/singularity-images"
+profiles {
+  standard {
+    process.executor = 'local'
+    process.memory = '5GB'
+    process.cpus = 1
+    singularity {
+      enabled = true
+      autoMounts = true
+    }
+  }
+
+  lsf {
+    process.executor = 'lsf'
+    process.memory = '5GB'
+    process.cpus = 1
+    process.clusterOptions = '-R "select[mem>5000] rusage[mem=5000]" -M5000'
+
+    // process {
+      // queue = 'short'
+      // withLabel: default {
+      //   clusterOptions = '-R"select[mem>2000] rusage[mem=2000]" -M2000'
+      // }
+      // withLabel: medmem {
+      //   clusterOptions = '-R"select[mem>8000] rusage[mem=8000]" -M8000'
+      // }
+      // withLabel: urgent {
+      //  clusterOptions = '-R"select[mem>2000] rusage[mem=2000]" -M2000'
+      // }
+      // withLabel: higmem {
+      //   clusterOptions = '-R"select[mem>16000] rusage[mem=16000]" -M16000'
+      // }
+      // withLabel: long {
+      //   clusterOptions = '-R"select[mem>2000] rusage[mem=2000]" -M2000'
+      // }
+    // }
+
+    singularity {
+      enabled = true
+      autoMounts = true
+    }
+  }
+
+  //untested 
+  slurm {
+    process.executor = 'slurm'
+    process.memory = '5GB' 
+    process.cpus = 1
+    process.clusterOptions = '--mem=5G'
+    singularity {
+      enabled = true
+      autoMounts = true
+    }
+  }  
+}
+
+params.chros = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT"
+params.vep_config = "$PWD/nf_config/vep.ini"

--- a/new_pipeline_dx/VEP/nf_config/vep.ini
+++ b/new_pipeline_dx/VEP/nf_config/vep.ini
@@ -1,0 +1,5 @@
+cache 1
+dir_cache '/nfs/production/flicek/ensembl/variation/data/VEP/tabixconverted'
+assembly 'GRCh38'
+offline 1
+force_overwrite 1

--- a/new_pipeline_dx/VEP/nf_config/vep.ini.template
+++ b/new_pipeline_dx/VEP/nf_config/vep.ini.template
@@ -1,0 +1,5 @@
+cache 1
+dir_cache  <path/to/cache/directory>
+assembly 'GRCh38'
+offline 1
+force_overwrite 1

--- a/new_pipeline_dx/VEP/nf_modules/merge_chros_VCF.nf
+++ b/new_pipeline_dx/VEP/nf_modules/merge_chros_VCF.nf
@@ -28,7 +28,7 @@ process mergeVCF {
     mode:'copy'
     
   cpus params.cpus
-  container "quay.io/biocontainers/bcftools:1.13--h3a49de5_0"
+  container "quay.io/biocontainers/bcftools:1.15.1--h0ea216a_0"
    
   input:
   path(vcfFiles)

--- a/new_pipeline_dx/VEP/nf_modules/merge_chros_VCF.nf
+++ b/new_pipeline_dx/VEP/nf_modules/merge_chros_VCF.nf
@@ -1,0 +1,47 @@
+#!/usr/bin/env nextflow
+
+/* 
+ * Script to merge chromosome-wise VCF files into single VCF file
+ */
+
+nextflow.enable.dsl=2
+
+// defaults
+prefix = "out"
+mergedVCF = "merged-file"
+params.outdir = ""
+params.cpus = 1
+
+process mergeVCF {
+  /*
+  Function to merge chromosome-wise VCF files into single VCF file
+
+  Returns
+  -------
+  Returns 2 files:
+      1) A VCF format file 
+      2) A tabix index for that VCF
+  */
+
+  publishDir "${params.outdir}", 
+    enabled: "${params.outdir}" as Boolean,
+    mode:'copy'
+    
+  cpus params.cpus
+  container "quay.io/biocontainers/bcftools:1.13--h3a49de5_0"
+   
+  input:
+  path(vcfFiles)
+  path(indexFiles)
+
+  output:
+  path("${ mergedVCF }.vcf.gz"), emit: vcfFile                                     
+  path("${ mergedVCF }.vcf.gz.tbi"), emit: indexFile
+
+  script: 
+  """
+  bcftools concat ${ vcfFiles } -Oz -o temp-${ mergedVCF}.vcf.gz
+  bcftools sort -Oz temp-${ mergedVCF}.vcf.gz -o ${ mergedVCF}.vcf.gz 
+  bcftools  index -t ${ mergedVCF}.vcf.gz
+  """
+}

--- a/new_pipeline_dx/VEP/nf_modules/run_vep_chros.nf
+++ b/new_pipeline_dx/VEP/nf_modules/run_vep_chros.nf
@@ -1,0 +1,52 @@
+#!/usr/bin/env nextflow
+
+/* 
+ * Script to run VEP on chromosome-wise split VCF files
+ */
+
+nextflow.enable.dsl=2
+
+// defaults
+prefix = "vep"
+params.outdir = ""
+params.cpus = 1
+
+process chrosVEP {
+  /*
+  Function to run VEP on chromosome-wise split VCF files
+
+  Returns
+  -------
+  Returns 2 files per chromosome:
+      1) VEP output file for each chromosome-wise split VCF
+      2) A tabix index for that VCF output file
+  */
+  publishDir "${params.outdir}/vep-summary",
+    pattern: "${prefix}-*.vcf.gz_summary.html",
+    mode:'move'
+  cpus params.cpus
+  container "ensemblorg/ensembl-vep:latest"
+
+  input:
+  tuple path(vcfFile), path(indexFile)
+  path(vep_config)
+  
+  output:
+  path("${prefix}-*.vcf.gz"), emit: vcfFile
+  path("${prefix}-*.vcf.gz.tbi"), emit: indexFile
+  path("${prefix}-*.vcf.gz_summary.html")
+
+  script:
+  if( !vcfFile.exists() ) {
+    exit 1, "VCF file is not generated: ${vcfFile}"
+  }
+  else if ( !indexFile.exists() ){
+    exit 1, "VCF index file is not generated: ${indexFile}"
+  }
+  else {
+    """
+    vep -i ${vcfFile} -o ${prefix}-${vcfFile} --vcf --compress_output bgzip --format vcf --config ${vep_config} 
+    tabix -p vcf ${prefix}-${vcfFile}
+    """	
+  }
+}

--- a/new_pipeline_dx/VEP/nf_modules/split_into_chros.nf
+++ b/new_pipeline_dx/VEP/nf_modules/split_into_chros.nf
@@ -1,0 +1,40 @@
+#!/usr/bin/env nextflow
+
+/* 
+ * Script to split a multi-chromosome VCF into single-chromosome VCFs
+ */
+
+nextflow.enable.dsl=2
+
+// defaults
+prefix = "out"
+params.outdir = ""
+params.cpus = 1
+
+process splitVCF {
+  /*
+  Function to split a multi-chromosome VCF into single chromosome VCF
+
+  Returns
+  -------
+  Returns 2 files per chromosome:
+      1) A VCF format file for each splitted chromosome
+      2) A tabix index for that VCF
+  */
+  cpus params.cpus
+  container "quay.io/biocontainers/bcftools:1.13--h3a49de5_0"
+
+  input:
+  val(chr)
+  path(vcf)
+  path(vcf_index)
+
+  output:
+  tuple path("${prefix}.${chr}.vcf.gz"), path("${prefix}.${chr}.vcf.gz.tbi")
+
+  script:
+  """
+  bcftools view -r ${chr} ${vcf} -o ${prefix}.${chr}.vcf.gz -O z
+  bcftools index -t ${prefix}.${chr}.vcf.gz
+  """
+}

--- a/new_pipeline_dx/VEP/nf_modules/split_into_chros.nf
+++ b/new_pipeline_dx/VEP/nf_modules/split_into_chros.nf
@@ -22,7 +22,7 @@ process splitVCF {
       2) A tabix index for that VCF
   */
   cpus params.cpus
-  container "quay.io/biocontainers/bcftools:1.13--h3a49de5_0"
+  container "quay.io/biocontainers/bcftools:1.15.1--h0ea216a_0"
 
   input:
   val(chr)

--- a/new_pipeline_dx/VEP/workflows/run_vep.nf
+++ b/new_pipeline_dx/VEP/workflows/run_vep.nf
@@ -1,0 +1,88 @@
+/* 
+ * Workflow to run VEP on chromosome based VCF files
+ *
+ * This workflow relies on Nextflow (see https://www.nextflow.io/tags/workflow.html)
+ *
+ */
+
+nextflow.enable.dsl=2
+
+ // params default
+params.help = false
+params.cpus = 1
+params.outdir = "outdir"
+params.vep_config="nf_config/vep.ini"
+
+// module imports
+include { splitVCF } from '../nf_modules/split_into_chros.nf' 
+include { mergeVCF } from '../nf_modules/merge_chros_VCF.nf'  
+include { chrosVEP } from '../nf_modules/run_vep_chros.nf'
+
+ // print usage
+if (params.help) {
+  log.info ''
+  log.info 'Pipeline to run VEP chromosome-wise'
+  log.info '-------------------------------------------------------'
+  log.info ''
+  log.info 'Usage: '
+  log.info '  nextflow -C nf_config/nextflow.config run workflows/run_vep.nf --vcf <path-to-vcf> --chros 1,2 --vep_config'
+  log.info ''
+  log.info 'Options:'
+  log.info '  --vcf VCF                 VCF that will be split. Currently supports sorted and bgzipped file'
+  log.info '  --outdir DIRNAME          Name of output dir. Default: outdir'
+  log.info '  --vep_config FILENAME     VEP config file. Default: nf_config/vep.ini'
+  log.info '  --chros LIST_OF_CHROS	Comma-separated list of chromosomes to generate. i.e. 1,2,... Default: 1,2,...,X,Y,MT'
+  log.info '  --cpus INT	        Number of CPUs to use. Default 1.'
+  exit 1
+}
+
+// Input validation
+if( !params.chros) {
+  exit 1, "Undefined --chros parameter. Please provide a comma-separated string with chromosomes: 1,2, ... Default: 1,2,...,X,Y,MT"
+}
+if( !params.vcf) {
+  exit 1, "Undefined --vcf parameter. Please provide the path to a VCF file"
+}
+
+vcfFile = file(params.vcf)
+if( !vcfFile.exists() ) {
+  exit 1, "The specified VCF file does not exist: ${params.vcf}"
+}
+
+check_bgzipped = "bgzip -t $params.vcf".execute()
+check_bgzipped.waitFor()
+if(check_bgzipped.exitValue()){
+  exit 1, "The specified VCF file is not bgzipped: ${params.vcf}"
+}
+
+//def sout = new StringBuilder(), serr = new StringBuilder()
+//check_parsing = "$params.singularity_dir/vep.sif tabix -p vcf -f $params.vcf".execute()
+//check_parsing.consumeProcessOutput(sout, serr)
+//check_parsing.waitFor()
+//if( serr ){
+//  exit 1, "The specified VCF file has issues in parsing: $serr"
+//}
+vcf_index = "${params.vcf}.tbi"
+
+vepFile = file(params.vep_config)
+if( !vepFile.exists() ) {
+  exit 1, "The specified VEP config does not exist: ${params.vep_config}"
+}
+
+log.info 'Starting workflow.....'
+
+workflow run_vep {
+  main:
+    chr_str = params.chros.toString()
+    chr = Channel.of(chr_str.split(',')).view()
+    splitVCF(chr, file( params.vcf ), file( vcf_index ))
+    chrosVEP(splitVCF.out, file( params.vep_config ))
+    mergeVCF(chrosVEP.out.vcfFile.collect(), chrosVEP.out.indexFile.collect())
+  emit:
+    vcfFile = mergeVCF.out.vcfFile
+    indexFile = mergeVCF.out.indexFile
+}  
+
+workflow {
+  run_vep()
+}

--- a/new_pipeline_dx/VEP_2_protein_function/nextflow.config
+++ b/new_pipeline_dx/VEP_2_protein_function/nextflow.config
@@ -1,0 +1,82 @@
+params.singularity_dir = "$PWD/singularity-images"
+profiles {
+  standard {
+    process.executor = 'local'
+    process.memory = '5GB'
+    process.cpus = 1
+    singularity {
+      enabled = true
+      autoMounts = true
+    }
+  }
+
+  lsf {
+    process.executor = 'lsf'
+    process.memory = '5GB'
+    process.cpus = 1
+    // process.clusterOptions = '-R "select[mem>5000] rusage[mem=5000]" -M5000'
+
+    // process.queue = 'short'
+
+    // process {
+      // queue = 'short'
+      // withLabel: default {
+      //   clusterOptions = '-R"select[mem>2000] rusage[mem=2000]" -M2000'
+      // }
+      // withLabel: medmem {
+      //   clusterOptions = '-R"select[mem>8000] rusage[mem=8000]" -M8000'
+      // }
+      // withLabel: urgent {
+      //  clusterOptions = '-R"select[mem>2000] rusage[mem=2000]" -M2000'
+      // }
+      // withLabel: higmem {
+      //   clusterOptions = '-R"select[mem>16000] rusage[mem=16000]" -M16000'
+      // }
+      // withLabel: long {
+      //   clusterOptions = '-R"select[mem>2000] rusage[mem=2000]" -M2000'
+      // }
+    // }
+
+    singularity {
+      enabled = true
+      autoMounts = true
+    }
+  }
+
+  //untested 
+  slurm {
+    process.executor = 'slurm'
+    process.memory = '5GB' 
+    process.cpus = 1
+    process.clusterOptions = '--mem=5G'
+    singularity {
+      enabled = true
+      autoMounts = true
+    }
+  }  
+}
+
+trace {
+    enabled = true
+    file = "reports/trace.txt"
+    //fields = 'task_id,name,status,exit,realtime,%cpu,rss'
+}
+
+dag {
+    enabled = true
+    file = "reports/flowchart.html"
+}
+
+timeline {
+    enabled = true
+    overwrite = true
+    file = "reports/timeline.html"
+}
+
+report {
+    enabled = true
+    file = "reports/report.html"
+}
+
+params.chros = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT"
+params.vep_config = "$PWD/nf_config/vep.ini"

--- a/new_pipeline_dx/VEP_2_protein_function/nf_config
+++ b/new_pipeline_dx/VEP_2_protein_function/nf_config
@@ -1,0 +1,1 @@
+../VEP/nf_config/

--- a/new_pipeline_dx/VEP_2_protein_function/nf_modules/create_subs.nf
+++ b/new_pipeline_dx/VEP_2_protein_function/nf_modules/create_subs.nf
@@ -4,7 +4,7 @@ process create_subs {
   */
 
   tag "$vcf"
-  // container "biocontainers/bcftools:v1.9-1-deb_cv1"
+  container "quay.io/biocontainers/bcftools:1.15.1--h0ea216a_0"
   memory '4 GB'
   // errorStrategy 'ignore'
 
@@ -15,7 +15,6 @@ process create_subs {
     path '*.subs'
 
   """
-  export BCFTOOLS_PLUGINS=${params.bcftools_plugins}
   bcftools +split-vep $vcf -d -A tab -s :missense \
            -f '%CHROM-%POS %Feature %Protein_position %Amino_acids\n' | \
            sed 's|/|\\t|g' > protein.subs

--- a/new_pipeline_dx/VEP_2_protein_function/nf_modules/create_subs.nf
+++ b/new_pipeline_dx/VEP_2_protein_function/nf_modules/create_subs.nf
@@ -1,0 +1,25 @@
+process create_subs {
+  /*
+  Generate amino acid substitutions
+  */
+
+  tag "$vcf"
+  // container "biocontainers/bcftools:v1.9-1-deb_cv1"
+  memory '4 GB'
+  // errorStrategy 'ignore'
+
+  input:
+    path vcf
+
+  output:
+    path '*.subs'
+
+  """
+  export BCFTOOLS_PLUGINS=${params.bcftools_plugins}
+  bcftools +split-vep $vcf -d -A tab -s :missense \
+           -f '%CHROM-%POS %Feature %Protein_position %Amino_acids\n' | \
+           sed 's|/|\\t|g' > protein.subs
+  awk '{print \$2 "\\t" \$3 "\\t" \$4 "\\t" \$5 > ( \$1 "_" \$2 ".subs" ) }' protein.subs  
+  rm protein.subs
+  """
+}

--- a/new_pipeline_dx/VEP_2_protein_function/nf_modules/fasta.nf
+++ b/new_pipeline_dx/VEP_2_protein_function/nf_modules/fasta.nf
@@ -1,0 +1,44 @@
+process linearise_fasta {
+  /*
+  Linearise FASTA file
+  */
+
+  tag "${fasta.baseName}"
+
+  input:
+    path fasta
+
+  output:
+    path 'linear.fa'
+
+  script:
+  """
+  cat $fasta > combined.fa
+  sed -e 's/\\(^>.*\$\\)/#\\1#/' combined.fa | \
+    tr -d "\\r" | \
+    tr -d "\\n" | \
+    sed -e 's/\$/#/' | \
+    tr "#" "\\n" | sed -e '/^\$/d' > linear.fa
+  """
+}
+
+process get_fasta {
+  /*
+  Get FASTA sequence for sequences in substitution file
+  */
+
+  tag "${subs.baseName}"
+
+  input:
+    path fasta
+    path subs
+
+  output:
+    path '*.fa', emit: fasta
+
+  """
+  query=\$(awk '{print \$1}' $subs | uniq)
+  grep -A1 \$query $fasta > \$query.fa
+  rm $fasta
+  """
+}

--- a/new_pipeline_dx/VEP_2_protein_function/nf_modules/split_gtf.nf
+++ b/new_pipeline_dx/VEP_2_protein_function/nf_modules/split_gtf.nf
@@ -1,0 +1,18 @@
+process split_gtf {
+  /*
+  Split GTF into multiple files
+  */
+
+  tag "${gtf.baseName}"
+  container "quay.io/biocontainers/agat:0.9.0--pl5321hdfd78af_0"
+
+  input:
+    path gtf
+
+  output:
+    path '*.gtf'
+
+  """
+  agat_sq_split.pl --input $gtf -o split.gtf
+  """
+}

--- a/new_pipeline_dx/VEP_2_protein_function/run_all.nf
+++ b/new_pipeline_dx/VEP_2_protein_function/run_all.nf
@@ -6,7 +6,6 @@ nextflow.enable.dsl=2
 
 params.help = false
 params.outdir = "outdir"
-params.bcftools_plugins = "/hps/software/users/ensembl/ensw/C8-MAR21-sandybridge/linuxbrew/Cellar/bcftools/1.12/libexec/bcftools/"
 
 // print usage
 if (params.help) {

--- a/new_pipeline_dx/VEP_2_protein_function/run_all.nf
+++ b/new_pipeline_dx/VEP_2_protein_function/run_all.nf
@@ -1,0 +1,44 @@
+/*
+ * From VCF to protein prediction
+ */
+
+nextflow.enable.dsl=2
+
+params.help = false
+params.outdir = "outdir"
+params.bcftools_plugins = "/hps/software/users/ensembl/ensw/C8-MAR21-sandybridge/linuxbrew/Cellar/bcftools/1.12/libexec/bcftools/"
+
+// print usage
+if (params.help) {
+  log.info ''
+  log.info 'Pipeline to run VEP and SIFT/PolyPhen2 based on a VCF file'
+  log.info '----------------------------------------------------------'
+  log.info ''
+  log.info 'Usage: '
+  log.info '  nextflow run run_all.nf --fasta $fasta --gtf $gtf --vcf $vcf --chros 21,22 -profile lsf -resume'
+  log.info ''
+  log.info 'Options:'
+  log.info '  --vcf VCF      VCF containing missense variants for protein function prediction'
+  exit 1
+}
+
+include { run_vep } from '../VEP/workflows/run_vep.nf'
+include { getTranslation } from '../protein_function/nf_modules/run_agat.nf'
+include { pph2 } from '../protein_function/nf_modules/run_polyphen2.nf'
+include { create_subs } from './nf_modules/create_subs.nf'
+include { linearise_fasta; get_fasta } from './nf_modules/fasta.nf'
+
+workflow {
+  // Get translated FASTA
+  getTranslation( file(params.gtf), file(params.fasta) )
+  linearise_fasta( getTranslation.out.collect() )
+
+  // Get substitutions
+  run_vep()  
+  create_subs( run_vep.out.vcfFile )
+  subs = create_subs.out.flatten()
+  translated = get_fasta ( linearise_fasta.out, subs )
+
+  // For each transcript, predict protein function
+  pph2(translated.fasta, subs)
+}

--- a/new_pipeline_dx/protein_function/README.md
+++ b/new_pipeline_dx/protein_function/README.md
@@ -1,0 +1,8 @@
+
+To run this workflow:
+
+```
+bsub nextflow -C nf_config/nextflow.config \
+              run workflows/run_protein_prediction.nf \
+              -profile lsf -resume
+```

--- a/new_pipeline_dx/protein_function/nf_config/nextflow.config
+++ b/new_pipeline_dx/protein_function/nf_config/nextflow.config
@@ -1,0 +1,66 @@
+profiles {
+  standard {
+    process.executor = 'local'
+    singularity {
+      enabled = true
+      autoMounts = true
+    }
+  }
+
+  lsf {
+    process {
+      executor = 'lsf'
+      // queue = 'short'
+      // withLabel: default {
+      //   clusterOptions = '-R"select[mem>2000] rusage[mem=2000]" -M2000'
+      // }
+      // withLabel: medmem {
+      //   clusterOptions = '-R"select[mem>8000] rusage[mem=8000]" -M8000'
+      // }
+      // withLabel: urgent {
+      //  clusterOptions = '-R"select[mem>2000] rusage[mem=2000]" -M2000'
+      // }
+      // withLabel: higmem {
+      //   clusterOptions = '-R"select[mem>16000] rusage[mem=16000]" -M16000'
+      // }
+      // withLabel: long {
+      //   clusterOptions = '-R"select[mem>2000] rusage[mem=2000]" -M2000'
+      // }
+    }
+    singularity {
+      enabled = true
+      autoMounts = true
+    }
+  }
+
+  //untested 
+  slurm {
+    process.executor = 'slurm'
+    singularity {
+      enabled = true
+      autoMounts = true
+    }
+  }  
+}
+
+trace {
+    enabled = true
+    file = "reports/trace.txt"
+    //fields = 'task_id,name,status,exit,realtime,%cpu,rss'
+}
+
+dag {
+    enabled = true
+    file = "reports/flowchart.html"
+}
+
+timeline {
+    enabled = true
+    overwrite = true
+    file = "reports/timeline.html"
+}
+
+report {
+    enabled = true
+    file = "reports/report.html"
+}

--- a/new_pipeline_dx/protein_function/nf_modules/create_substitutions.nf
+++ b/new_pipeline_dx/protein_function/nf_modules/create_substitutions.nf
@@ -1,0 +1,46 @@
+#!/usr/bin/env nextflow
+
+process getAminoacidSubstitutions {
+  /*
+  Generate all aminoacid substitutions for SIFT or Polyphen-2
+
+  Returns
+  -------
+  Returns 1 file:
+      1) Substitutions file 'subs.txt'
+  */
+
+  tag "${peptide.id}"
+
+  input:
+    val peptide
+    val program 
+
+  output:
+    path 'subs.txt'
+
+  shell:
+  '''
+  ALL_AAS=(A C D E F G H I K L M N P Q R S T V W Y)
+  pos=0
+  program=!{program}
+  for ref in `grep -o . <<< !{peptide.seqString}`; do
+    ((pos+=1))
+    # ignore non-standard amino acids (e.g. X) when using PolyPhen-2
+    if [[ $program == "polyphen2" && ! " ${ALL_AAS[*]} " =~ " ${ref} " ]]; then
+      continue
+    fi
+
+    for alt in ${ALL_AAS[@]}; do
+      if [[ $ref == $alt ]]; then
+        continue
+      elif [[ $program == "sift" ]]; then
+        output="$ref$pos$alt"
+      elif [[ $program == "polyphen2" ]]; then
+        output="!{peptide.id}\t$pos\t$ref\t$alt"
+      fi
+        echo $output >> subs.txt
+    done
+  done
+  '''
+}

--- a/new_pipeline_dx/protein_function/nf_modules/run_agat.nf
+++ b/new_pipeline_dx/protein_function/nf_modules/run_agat.nf
@@ -1,0 +1,39 @@
+#!/usr/bin/env nextflow
+
+/*
+ * AGAT: Another GTF/GFF Analysis Toolkit
+ */
+
+process getTranslation {
+  /*
+  Translate nucleotide FASTA sequences based on GTF features
+
+  Returns
+  -------
+  Returns 1 file:
+      1) Protein FASTA sequence 'translated.fa'
+  */
+
+  tag "${gtf}"
+  container "quay.io/biocontainers/agat:0.9.0--pl5321hdfd78af_0"
+  memory '20 GB'
+  publishDir "${params.outdir}"
+
+  input:
+    path gtf
+    path fasta
+
+  output:
+    path '*_translated.fa'
+
+  script:
+    """
+    agat_sp_extract_sequences.pl -g $gtf -f $fasta --protein \
+                                 -o ${gtf.baseName}_translated.fa
+    """
+
+  stub:
+    """
+    cp /homes/nuno/workspace/sift-polyphen2-nextflow-vep-4667/ensembl-vep/nextflow/protein_function/outdir/translated.fa .
+    """
+}

--- a/new_pipeline_dx/protein_function/nf_modules/run_polyphen2.nf
+++ b/new_pipeline_dx/protein_function/nf_modules/run_polyphen2.nf
@@ -28,7 +28,7 @@ process pph2 {
   */
 
   tag "${subs.baseName}"
-  container "${params.singularity_dir}/polyphen2.sif"
+  container "nunoagostinho/polyphen-2:2.2.3"
   containerOptions "--bind $dssp,$wwpdb,$precomputed,$nrdb,$pdb2fasta,$ucsc,$uniprot"
   memory '4 GB'
   errorStrategy 'ignore'
@@ -61,7 +61,7 @@ process weka {
       2) Error '*.err'
   */
 
-  container "${params.singularity_dir}/polyphen2.sif"
+  container "nunoagostinho/polyphen-2:2.2.3"
   errorStrategy 'ignore'
 
   input:

--- a/new_pipeline_dx/protein_function/nf_modules/run_polyphen2.nf
+++ b/new_pipeline_dx/protein_function/nf_modules/run_polyphen2.nf
@@ -1,0 +1,77 @@
+#!/usr/bin/env nextflow
+
+/* 
+ * Predict protein function using PolyPhen
+ */
+
+params.polyphen2_data = "/hps/nobackup/flicek/ensembl/variation/nuno/sift-polyphen2-nextflow-4667/input/polyphen2"
+
+// PolyPhen-2 data directories to bind
+PPH="/opt/pph2" // PolyPhen-2 directory in Singularity container
+dssp="${params.polyphen2_data}/dssp:$PPH/dssp"
+wwpdb="${params.polyphen2_data}/wwpdb:$PPH/wwpdb"
+precomputed="${params.polyphen2_data}/precomputed:$PPH/precomputed"
+nrdb="${params.polyphen2_data}/nrdb:$PPH/nrdb"
+pdb2fasta="${params.polyphen2_data}/pdb2fasta:$PPH/pdb2fasta"
+ucsc="${params.polyphen2_data}/ucsc:$PPH/ucsc"
+uniprot="${params.polyphen2_data}/uniprot:$PPH/uniprot"
+
+process pph2 {
+  /*
+  Run PolyPhen-2 on a protein sequence with a substitions file
+
+  Returns
+  -------
+  Returns 2 files:
+      1) Output '*.txt'
+      2) Errors '*.err'
+  */
+
+  tag "${subs.baseName}"
+  container "${params.singularity_dir}/polyphen2.sif"
+  containerOptions "--bind $dssp,$wwpdb,$precomputed,$nrdb,$pdb2fasta,$ucsc,$uniprot"
+  memory '4 GB'
+  errorStrategy 'ignore'
+
+  input:
+    path protein
+    path subs
+
+  output:
+    path '*.txt'
+    path '*.err'
+
+  publishDir "${params.outdir}/polyphen-2"
+
+  """
+  mkdir -p tmp/lock
+  run_pph.pl -A -d tmp -s $protein $subs \
+             1> ${subs.baseName}.txt 2> ${subs.baseName}.err
+  """
+}
+
+process weka {
+  /*
+  Run Weka
+
+  Returns
+  -------
+  Returns 2 files:
+      1) Output '*.txt'
+      2) Error '*.err'
+  */
+
+  container "${params.singularity_dir}/polyphen2.sif"
+  errorStrategy 'ignore'
+
+  input:
+    path model
+    path in
+
+  output:
+    path '${model}.*'
+
+  """
+  run_weka.pl -l $model $in 1> ${model}.txt 2> ${model}.err
+  """
+}

--- a/new_pipeline_dx/protein_function/nf_modules/run_sift.nf
+++ b/new_pipeline_dx/protein_function/nf_modules/run_sift.nf
@@ -12,7 +12,7 @@ process alignProteins {
   */
 
   tag "$fasta"
-  container "${params.singularity_dir}/sift.sif" 
+  container "nunoagostinho/sift:6.2.1"
   memory '4 GB'
   errorStrategy 'ignore'
 
@@ -44,7 +44,7 @@ process sift {
   */
 
   tag "${aln}"
-  container "${params.singularity_dir}/sift.sif"
+  container "nunoagostinho/sift:6.2.1"
   memory '4 GB'
   errorStrategy 'ignore'
   publishDir "${params.outdir}/sift"

--- a/new_pipeline_dx/protein_function/nf_modules/run_sift.nf
+++ b/new_pipeline_dx/protein_function/nf_modules/run_sift.nf
@@ -1,0 +1,62 @@
+#!/usr/bin/env nextflow
+
+/* 
+ * Predict protein function using SIFT
+ */
+
+blastdb_name = file(params.blastdb).name
+
+process alignProteins {
+  /*
+  Run multiple alignment for protein sequence
+  */
+
+  tag "$fasta"
+  container "${params.singularity_dir}/sift.sif" 
+  memory '4 GB'
+  errorStrategy 'ignore'
+
+  input:
+    path fasta
+    path blastdb_dir
+
+  output:
+    path '*.alignedfasta'
+
+  """
+  #!/bin/csh
+  setenv tmpdir "."
+  setenv NCBI "/opt/blast/bin/"
+  seqs_chosen_via_median_info.csh $fasta \
+                                  $blastdb_dir/$blastdb_name \
+                                  $params.median_cutoff
+  """
+}
+
+process sift {
+  /*
+  Run SIFT
+
+  Returns
+  -------
+  Returns 1 file:
+      1) Output 'protein.SIFTprediction'
+  */
+
+  tag "${aln}"
+  container "${params.singularity_dir}/sift.sif"
+  memory '4 GB'
+  errorStrategy 'ignore'
+  publishDir "${params.outdir}/sift"
+
+  input:
+    path aln
+    path subs
+
+  output:
+    path '*.SIFTprediction'
+
+  """
+  info_on_seqs $aln $subs protein.SIFTprediction
+  """
+}

--- a/new_pipeline_dx/protein_function/workflows/run_protein_prediction.nf
+++ b/new_pipeline_dx/protein_function/workflows/run_protein_prediction.nf
@@ -1,0 +1,105 @@
+/* 
+ * Nextflow pipeline to predict protein function using SIFT and PolyPhen-2
+ */
+
+nextflow.enable.dsl=2
+
+// default params
+params.help = false
+params.outdir = "outdir"
+params.singularity_dir = "singularity-images"
+
+// params.gtf="input/annotation/sample.gtf"
+params.gtf="input/annotation/sample_human.gtf"
+// params.fasta="input/fasta/Canis_lupus_familiarisbasenji.Basenji_breed-1.1.dna_sm.toplevel.fa"
+params.fasta="input/fasta/Homo_sapiens.GRCh38.dna_sm.toplevel.fa"
+params.program="polyphen2"
+
+// SIFT-specific parameters
+params.median_cutoff = 2.75 // as per SIFT's README
+params.blastdb="input/sift/uniref100/uniref100_seg.sift.fa"
+blastdb_name = file(params.blastdb).name
+blastdb_dir = file(params.blastdb).parent
+
+// module imports
+include { getTranslation }            from '../nf_modules/run_agat.nf'
+include { sift; alignProteins }       from '../nf_modules/run_sift.nf'
+include { pph2; weka }                from '../nf_modules/run_polyphen2.nf'
+include { getAminoacidSubstitutions } from '../nf_modules/create_substitutions.nf'
+
+// print usage
+if (params.help) {
+  log.info """
+  Pipeline to predict protein function using SIFT and PolyPhen-2
+  --------------------------------------------------------------
+
+  Usage:
+    nextflow -C nf_config/nextflow.config run \
+             workflows/run_protein_prediction.nf \
+             --gtf [path/to/gtf] --fasta [path/to/fasta] \
+             -profile lsf -resume
+
+  Options:
+    --gtf                  Annotation GTF file
+    --fasta                Genomic sequence FASTA file
+    --program              "sift" (SIFT) or "polyphen2" (PolyPhen-2). Default: "sift"
+    --outdir DIRNAME       Name of output dir. Default: outdir
+
+  SIFT options:
+    --blastdb DIR          Path to SIFT-formatted BLAST database, e.g. uniref100
+    --median_cutoff VALUE  Protein alignment's median cutoff. Default: 2.75
+  """
+  exit 1
+}
+
+log.info """
+  Starting workflow...
+    GTF     : ${params.gtf}
+    FASTA   : ${params.fasta}
+    program : ${params.program}
+"""
+
+workflow run_protein_prediction {
+  // Translate transcripts from GTF and FASTA
+  getTranslation(file(params.gtf), file(params.fasta))
+  translated = getTranslation.out.splitFasta(by: 1, file: true)
+
+  // Generate aminoacid substitutions
+  translated_rec = translated.splitFasta(record: [id: true, seqString: true ])
+  getAminoacidSubstitutions(translated_rec, params.program)
+  subs = getAminoacidSubstitutions.out
+
+  if ( params.program == "sift" ) {
+    // Align translated sequences against BLAST database
+    alignProteins(translated, blastdb_dir)
+    aligned = alignProteins.out
+
+    // Run SIFT
+    sift(aligned, subs)
+  } else if (params.program == "polyphen2" ) {
+    // Run PolyPhen-2
+    pph2(translated, subs)
+    // weka()
+  }
+}
+
+workflow {
+  run_protein_prediction()
+}
+
+// Print summary
+workflow.onComplete {
+    println ( workflow.success ? """
+        Workflow summary
+        ----------------
+        Completed at: ${workflow.complete}
+        Duration    : ${workflow.duration}
+        Success     : ${workflow.success}
+        workDir     : ${workflow.workDir}
+        exit status : ${workflow.exitStatus}
+        """ : """
+        Failed: ${workflow.errorReport}
+        exit status : ${workflow.exitStatus}
+        """
+    )
+}


### PR DESCRIPTION
Hey @rsalz, here follows the code to run VEP and protein prediction.

Since our meeting, I made the following enhancements:
* Docker images for [SIFT 6.2.1](https://hub.docker.com/r/nunoagostinho/sift) and [PolyPhen-2 2.2.3](https://hub.docker.com/r/nunoagostinho/polyphen-2) are now available in my personal Docker Hub
  * The pipeline automatically downloads the images when running for the first time
  * In the future, we intend to host the images in our business Docker account, but not until we are satisfied with the pipeline
* `bcftools` was updated to a newer Docker image that contains the `split-vep` plugin and no longer requires local installation of the plugins

To run this pipeline, users still need to manually download PolyPhen-2 data: a step to be automated in the following weeks.

Cheers!