### PR TITLE
Fix VEP running for a single chromosome

### DIFF
--- a/VEP/nf_modules/utils.nf
+++ b/VEP/nf_modules/utils.nf
@@ -27,8 +27,7 @@ process prepare_vep_transcript_annotation {
     path dir_plugins
 
   output:
-    //path '*.ini'
-    path '*_plugin.ini'
+    path 'vep_config_plugin.ini'
 
   """
   new_config="vep_config_plugin.ini"

--- a/VEP_2_protein_function/main.nf
+++ b/VEP_2_protein_function/main.nf
@@ -67,11 +67,10 @@ workflow predict_protein_function {
 
     // Get substitutions
     create_subs( filter_common_variants.out.vep_filtered_vcf )
-    subs = create_subs.out.flatten()
-    get_fasta ( linearise_fasta.out, subs )
+    subs = create_subs.out.splitCsv(sep: "\t", header: true)
 
     // For each transcript, predict protein function
-    pph2(get_fasta.out)
+    pph2( linearise_fasta.out, subs )
     weka(params.model, pph2.out.results)
     res = weka.out.processed.collectFile(name: "weka_results.out")
 

--- a/VEP_2_protein_function/main.nf
+++ b/VEP_2_protein_function/main.nf
@@ -79,7 +79,7 @@ workflow predict_protein_function {
     prepare_vep_transcript_annotation( res, vep_config_complete, file("../VEP_2_protein_function/VEP_plugins") )
     run_vep_plugin( filter_common_variants.out.originally_benign_af_vcf,
                     filter_common_variants.out.originally_benign_af_vcf_index,
-                    prepare_vep_transcript_annotation.out )
+                    prepare_vep_transcript_annotation.out.first() )
 
     // create output files
     filter_high_severity( run_vep_plugin.out.vcfFile )
@@ -93,5 +93,5 @@ workflow predict_protein_function {
 
 workflow {
   predict_protein_function( file(params.gtf), file(params.fasta),
-                            file(params.vep_config) )
+                            file(params.vep_config), file(params.translated) )
 }

--- a/VEP_2_protein_function/nf_modules/create_subs.nf
+++ b/VEP_2_protein_function/nf_modules/create_subs.nf
@@ -6,19 +6,17 @@ process create_subs {
   tag "$vcf"
   container "quay.io/biocontainers/bcftools:1.15.1--h0ea216a_0"
   memory '4 GB'
-  // errorStrategy 'ignore'
 
   input:
     path vcf
 
   output:
-    path '*.subs'
+    path 'protein.subs'
 
   """
+  echo "chrom\tpos\tref\talt\tfeature\tprotein_pos\taa_ref\taa_alt" > protein.subs
   bcftools +split-vep $vcf -d -A tab -s :missense \
-           -f '%CHROM-%POS-%REF-%ALT %Feature %Protein_position %Amino_acids\n' | \
-           sed 's|/|\\t|g' > protein.subs
-  awk '{ file=\$1 "-" \$2 ".subs"; print \$2 "\\t" \$3 "\\t" \$4 "\\t" \$5 > file; close(file) }' protein.subs
-  rm protein.subs
+           -f '%CHROM\t%POS\t%REF\t%ALT\t%Feature\t%Protein_position\t%Amino_acids\n' |\
+           sed 's|/|\\t|g' >> protein.subs
   """
 }

--- a/VEP_2_protein_function/nf_modules/fasta.nf
+++ b/VEP_2_protein_function/nf_modules/fasta.nf
@@ -13,8 +13,7 @@ process linearise_fasta {
 
   script:
   """
-  cat $fasta > combined.fa
-  sed -e 's/\\(^>.*\$\\)/#\\1#/' combined.fa | \
+  sed -e 's/\\(^>.*\$\\)/#\\1#/' $fasta | \
     tr -d "\\r" | \
     tr -d "\\n" | \
     sed -e 's/\$/#/' | \

--- a/protein_function/workflows/run_protein_prediction.nf
+++ b/protein_function/workflows/run_protein_prediction.nf
@@ -28,7 +28,6 @@ params.model = "HumDiv.UniRef100.NBd.f11.model"
 include { getTranslation }            from '../nf_modules/run_agat.nf'
 include { sift; alignProteins }       from '../nf_modules/run_sift.nf'
 include { pph2; weka }                from '../nf_modules/run_polyphen2.nf'
-include { getAminoacidSubstitutions } from '../nf_modules/create_substitutions.nf'
 
 // print usage
 if (params.help) {


### PR DESCRIPTION
Hey @rsalz, can you test if these changes fix your issues?

Change log:
- Force `run_vep_plugin` to run for every chromosome: 
  - `prepare_vep_transcript_annotation` may return a list of one item instead of a single item itself (I was only able to reproduce this with the data that you sent me)
- Improve performance of PolyPhen-2 preparation:
  - Instead of creating a substitutions file for each variant and a protein FASTA sequence for each transcript before running PolyPhen-2, we can do it faster if we perform those actions in the same process before running PolyPhen-2
- Fix `linearise_fasta` not being cached